### PR TITLE
Cherry-pick AIRFLOW-2713, AIRFLOW-2716, AIRFLOW-2723

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -1,7 +1,13 @@
 # Updating Airflow
 
 This file documents any backwards-incompatible changes in Airflow and
-assists people when migrating to a new version.
+assists users migrating to a new version.
+
+## Airflow Master
+
+### Replace DataProcHook.await calls to DataProcHook.wait
+
+The method name was changed to be compatible with the Python 3.7 async/await keywords
 
 ## Airflow 1.9
 

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -98,9 +98,9 @@ class CeleryExecutor(BaseExecutor):
 
     def sync(self):
         self.log.debug("Inquiring about %s celery task(s)", len(self.tasks))
-        for key, async in list(self.tasks.items()):
+        for key, task in list(self.tasks.items()):
             try:
-                state = async.state
+                state = task.state
                 if self.last_state[key] != state:
                     if state == celery_states.SUCCESS:
                         self.success(key)
@@ -115,8 +115,8 @@ class CeleryExecutor(BaseExecutor):
                         del self.tasks[key]
                         del self.last_state[key]
                     else:
-                        self.log.info("Unexpected state: %s", async.state)
-                    self.last_state[key] = async.state
+                        self.log.info("Unexpected state: %s", task.state)
+                    self.last_state[key] = task.state
             except Exception as e:
                 self.log.error("Error syncing the celery executor, ignoring it:")
                 self.log.exception(e)
@@ -124,7 +124,7 @@ class CeleryExecutor(BaseExecutor):
     def end(self, synchronous=False):
         if synchronous:
             while any([
-                    async.state not in celery_states.READY_STATES
-                    for async in self.tasks.values()]):
+                    task.state not in celery_states.READY_STATES
+                    for task in self.tasks.values()]):
                 time.sleep(5)
         self.sync()

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,8 @@ def write_version(filename=os.path.join(*['airflow',
     with open(filename, 'w') as a:
         a.write(text)
 
-async = [
+
+async_packages = [
     'greenlet>=0.4.9',
     'eventlet>= 0.9.7',
     'gevent>=0.13'
@@ -180,7 +181,7 @@ devel = [
     'click',
     'freezegun',
     'jira',
-    'lxml>=3.3.4',
+    'lxml>=4.0.0',
     'mock',
     'moto==1.1.19',
     'nose',
@@ -225,7 +226,7 @@ def do_setup():
             'gitpython>=2.0.2',
             'gunicorn>=19.4.0, <20.0',
             'jinja2>=2.7.3, <2.9.0',
-            'lxml>=3.6.0, <4.0',
+            'lxml>=4.0.0',
             'markdown>=2.5.2, <3.0',
             'pandas>=0.17.1, <1.0.0',
             'psutil>=4.2.0, <5.0.0',
@@ -243,7 +244,7 @@ def do_setup():
         extras_require={
             'all': devel_all,
             'all_dbs': all_dbs,
-            'async': async,
+            'async': async_packages,
             'azure': azure,
             'celery': celery,
             'cgroups': cgroups,


### PR DESCRIPTION
[AIRFLOW-2713] Rename async variable in setup.py for Python 3.7.0 compatibility

Closes #3561 from Perados/rename-async-to-async_packages-in-setup

[AIRFLOW-2716] Replace async and await py3.7 keywords

Closes #3578 from JacobHayes/py37-keywords

[AIRFLOW-2723] Update lxml dependancy to >= 4.0.0

Closes #3583 from neil90/master